### PR TITLE
Print a warning instead of a trace if the build bulb is not plugged in

### DIFF
--- a/bulb_formatter.rb
+++ b/bulb_formatter.rb
@@ -12,7 +12,7 @@ class BulbFormatter < RSpec::Core::Formatters::ProgressFormatter
     begin
       @bulb = SerialPort.new(DEVICE, 9600)
       
-      if @buld.nil?
+      if @bulb.nil?
         puts "\nWARNING: Couldn't find build bulb"
         return
       end
@@ -25,7 +25,7 @@ class BulbFormatter < RSpec::Core::Formatters::ProgressFormatter
   def dump_summary(duration, example_count, failure_count, pending_count)
     super
 
-    if @buld.nil?
+    if @bulb.nil?
       puts "\nWARNING: Couldn't find build bulb"
       return
     end


### PR DESCRIPTION
Pretty simple... here's some example output.

```
Finished in 0.54901 seconds
5 examples, 3 failures

Failed examples:

rspec ./spec/models/device.rb:54 # Device should remove staff from the access list
rspec ./spec/models/device.rb:28 # Device should not add a staff member from another customer
rspec ./spec/models/device.rb:38 # Device should block access to staff that are not on the access list

WARNING: Couldn't find build bulb

Randomized with seed 35939
```
