### PR TITLE
Removed use of try

### DIFF
--- a/bulb_formatter.rb
+++ b/bulb_formatter.rb
@@ -31,11 +31,11 @@ class BulbFormatter < RSpec::Core::Formatters::ProgressFormatter
     end
 
     if failure_count.zero?
-      @bulb.try(:write, "g")
+      @bulb.write "g"
     else
-      @bulb.try(:write, "r")
+      @bulb.write "r"
     end
 
-    @bulb.try(:close)
+    @bulb.close
   end
 end


### PR DESCRIPTION
Did this because it's rails only and we already protect against bulb being nil above the calls to try.

```ruby
 def dump_summary(duration, example_count, failure_count, pending_count)
    super

    if @bulb.nil? # protect against bulb being nil
      puts "\nWARNING: Couldn't find build bulb"
      return
    end

    if failure_count.zero?
      @bulb.write "g"
    else
      @bulb.write "r"
    end

    @bulb.close
  end
```

Tested and working.