### PR TITLE
Drop in rubyserial to replace serialport

### DIFF
--- a/bulb_formatter.rb
+++ b/bulb_formatter.rb
@@ -1,7 +1,7 @@
 require 'rspec/core/formatters/progress_formatter'
 # dirty hack, see: https://github.com/carlhuda/bundler/issues/183
 $LOAD_PATH.concat Dir.glob("#{ENV['rvm_path']}/gems/#{ENV['RUBY_VERSION']}@global/gems/*/lib")
-require 'serialport'
+require 'rubyserial'
 
 class BulbFormatter < RSpec::Core::Formatters::ProgressFormatter
 
@@ -10,7 +10,7 @@ class BulbFormatter < RSpec::Core::Formatters::ProgressFormatter
   def initialize(output)
     super(output)
     begin
-      @bulb = SerialPort.new(DEVICE, 9600)
+      @bulb = Serial.new(DEVICE, 9600)
       
       if @bulb.nil?
         puts "\nWARNING: Couldn't find build bulb"


### PR DESCRIPTION
This is because the `serialport` gem doesn't seem to work in later versions of ruby or operating systems.  The following error was seen on the ruby:3.0.2 docker image.

```
symbol lookup error: /usr/local/bundle/gems/serialport-1.3.1/lib/serialport.so: undefined symbol: rb_secure
```

The `serialport` gems last update was in 2014 and uses a shared object file.  `rubyserial` doesn't require that compilation step and is a drop in replacement with the last update being in 2018.